### PR TITLE
Fixed realpath issue

### DIFF
--- a/easy2use
+++ b/easy2use
@@ -808,7 +808,7 @@ echo ""
 
 source utilities/cli/cli_utils.bash
 
-CLI_ROOT=$(dirname $(realpath $0))
+CLI_ROOT=$(dirname $(readlink -f $0 || realpath $0))
 verbose "CLI root: ${CLI_ROOT}"
 cd ${CLI_ROOT}
 


### PR DESCRIPTION
Fixed issue while using realpath in some environments.
Now using readlink and realpath both, whichever is applicable it will try to use that instead.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
In some environments, /usr/bin doesn't contain the realpath, so used the readlink whichever machine doesn't contain the realpath will try to use the readlink instead or whichever is applicable first.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
