### PR TITLE
Changed easy2use to use env bash in top of the script

### DIFF
--- a/easy2use
+++ b/easy2use
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 #   Copyright 2019 Ericsson AB.
 #   For a full list of individual contributors, please see the commit history.
@@ -14,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-#!/bin/bash
 
 # Global constants that needs to be configured here since no config file has
 # been read yet


### PR DESCRIPTION
#!/bin/bash seems to fail in some environment, e.g. in environments when system default bash is not working as it should.

Changing to "#!/usr/bin/env bash" so it pick the first bash installation it can find in PATH variable, If not found, it uses system default bash installation.

Moving also the shebang line to the top of the easy2use script before license text. This has caused some issues in different shell environments.

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
