### PR TITLE
Add Persistence storage configuration handling

### DIFF
--- a/bundles/Eiffel/K8S/k8s_bundle_functions.bash
+++ b/bundles/Eiffel/K8S/k8s_bundle_functions.bash
@@ -37,6 +37,8 @@ function execute_k8s_command_on_services {
           image.tag="$EIFFEL_MONGODB_VERSION"
           fullnameOverride="$K8S_SERVICE_EIFFEL_MONGODB"
           service.port="$EIFFEL_MONGODB_EXTERNAL_PORT"
+          persistence.enabled="$K8S_PVC_ENABLE"
+          persistence.size="$K8S_PVC_SIZE"
         )
         local valuefile="charts/charts_values/mongodb-values.yaml"
         local chart="charts/mongodb-9.3.1.tgz"
@@ -66,6 +68,8 @@ function execute_k8s_command_on_services {
           fullnameOverride="$K8S_SERVICE_EIFFEL_RABBITMQ"
           service.nodePort="$EIFFEL_RABBITMQ_AMQP_EXTERNAL_PORT"
           service.managerPort="$EIFFEL_RABBITMQ_WEB_EXTERNAL_PORT"
+          persistence.enabled="$K8S_PVC_ENABLE"
+          persistence.size="$K8S_PVC_SIZE"
         )
         local valuefile="charts/charts_values/rabbitmq-values.yaml"
         local chart="charts/rabbitmq-7.7.1.tgz"

--- a/bundles/Eiffel/K8S/k8s_bundle_functions.bash
+++ b/bundles/Eiffel/K8S/k8s_bundle_functions.bash
@@ -38,7 +38,6 @@ function execute_k8s_command_on_services {
           fullnameOverride="$K8S_SERVICE_EIFFEL_MONGODB"
           service.port="$EIFFEL_MONGODB_EXTERNAL_PORT"
           persistence.enabled="$K8S_PVC_ENABLE"
-          persistence.size="$K8S_PVC_SIZE"
           persistence.storageClass="$K8S_PVC_STORAGE_CLASS"
         )
         local valuefile="charts/charts_values/mongodb-values.yaml"
@@ -70,7 +69,6 @@ function execute_k8s_command_on_services {
           service.nodePort="$EIFFEL_RABBITMQ_AMQP_EXTERNAL_PORT"
           service.managerPort="$EIFFEL_RABBITMQ_WEB_EXTERNAL_PORT"
           persistence.enabled="$K8S_PVC_ENABLE"
-          persistence.size="$K8S_PVC_SIZE"
           persistence.storageClass="$K8S_PVC_STORAGE_CLASS"
         )
         local valuefile="charts/charts_values/rabbitmq-values.yaml"

--- a/bundles/Eiffel/K8S/k8s_bundle_functions.bash
+++ b/bundles/Eiffel/K8S/k8s_bundle_functions.bash
@@ -39,6 +39,7 @@ function execute_k8s_command_on_services {
           service.port="$EIFFEL_MONGODB_EXTERNAL_PORT"
           persistence.enabled="$K8S_PVC_ENABLE"
           persistence.size="$K8S_PVC_SIZE"
+          persistence.storageClass="$K8S_PVC_STORAGE_CLASS"
         )
         local valuefile="charts/charts_values/mongodb-values.yaml"
         local chart="charts/mongodb-9.3.1.tgz"
@@ -70,6 +71,7 @@ function execute_k8s_command_on_services {
           service.managerPort="$EIFFEL_RABBITMQ_WEB_EXTERNAL_PORT"
           persistence.enabled="$K8S_PVC_ENABLE"
           persistence.size="$K8S_PVC_SIZE"
+          persistence.storageClass="$K8S_PVC_STORAGE_CLASS"
         )
         local valuefile="charts/charts_values/rabbitmq-values.yaml"
         local chart="charts/rabbitmq-7.7.1.tgz"

--- a/config-default.bash
+++ b/config-default.bash
@@ -114,9 +114,8 @@ K8S_INGRESS_CERT_SECRET_NAME=""
 # ----------- Services Persistence Storage (PVC) configurations -------------------------------------
 # Some components support persitent storage in Kubernetes, e.g. MongoDb and RabbitMq in Eiffel bundle.
 # When persistence storage (PVC - PersistenceVolumeClaim) is enabled, data is not lossed in case of restart of pod/container.
-# There is two configuration
+# There is two configurations:
 # K8S_PVC_ENABLE : if set to true, then persistence storage will be used for components that support that.
-# K8S_PVC_SIZE : sets the size that need to be allocated per components that support the persistent storage.
 # K8S_PVC_STORAGE_CLASS : If defined, storageClassName: <storageClass>
 #                         If set to "-", storageClassName: "", which disables dynamic provisioning
 #                         If undefined (the default) or set to null, no storageClassName spec is
@@ -126,5 +125,4 @@ K8S_INGRESS_CERT_SECRET_NAME=""
 #                       
 # ------------------------------------------------------------------------------
 K8S_PVC_ENABLE=false
-K8S_PVC_SIZE=8Gi
 K8S_PVC_STORAGE_CLASS="null"

--- a/config-default.bash
+++ b/config-default.bash
@@ -109,3 +109,14 @@ HELM_VERSION=V3
 # ------------------------------------------------------------------------------
 K8S_INGRESS_TLS_ENABLE=false
 K8S_INGRESS_CERT_SECRET_NAME=""
+
+
+# ----------- Services Persistence Storage (PVC) configurations -------------------------------------
+# Some components support persitent storage in Kubernetes, e.g. MongoDb and RabbitMq in Eiffel bundle.
+# When persistence storage (PVC - PersistenceVolumeClaim) is enabled, data is not lossed in case of restart of pod/container.
+# There is two configuration
+# K8S_PVC_ENABLE : if set to true, then persistence storage will be used for components that support that.
+# K8S_PVC_SIZE : sets the size that need to be allocated per components that support the persistent storage.
+# ------------------------------------------------------------------------------
+K8S_PVC_ENABLE=false
+K8S_PVC_SIZE=8Gi

--- a/config-default.bash
+++ b/config-default.bash
@@ -117,6 +117,14 @@ K8S_INGRESS_CERT_SECRET_NAME=""
 # There is two configuration
 # K8S_PVC_ENABLE : if set to true, then persistence storage will be used for components that support that.
 # K8S_PVC_SIZE : sets the size that need to be allocated per components that support the persistent storage.
+# K8S_PVC_STORAGE_CLASS : If defined, storageClassName: <storageClass>
+#                         If set to "-", storageClassName: "", which disables dynamic provisioning
+#                         If undefined (the default) or set to null, no storageClassName spec is
+#                         set, choosing the default provisioner.  (gp2 on AWS, standard on
+#                         GKE, AWS & OpenStack)
+#                         storageClass: "-"
+#                       
 # ------------------------------------------------------------------------------
 K8S_PVC_ENABLE=false
 K8S_PVC_SIZE=8Gi
+K8S_PVC_STORAGE_CLASS="null"


### PR DESCRIPTION
Adding Persistence storage configuration handling and updated Eiffel bundle to handle the new configuration for MongoDB and RabbitMq instance.

Issue link: #55 

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Make it possible to start component that support persistence storage in Kubernetes PersistenceVolumeClaim.
So data persists if container/component restarts.

### Possible Drawbacks
No drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
