### PR TITLE
Update k8s_utils.bash script to remove statefulset pvc

### DIFF
--- a/utilities/cli/k8s_utils.bash
+++ b/utilities/cli/k8s_utils.bash
@@ -194,6 +194,9 @@ function do_execute_k8s_command_on_service {
           then
           helm uninstall "$releasename" --namespace "$K8S_NAMESPACE" \
           || print "Warning: Could not delete $releasename"
+          if [[ -n $(kubectl get pvc --namespace "$K8S_NAMESPACE" -l "app.kubernetes.io/instance=$releasename" 2>/dev/null) ]];then
+          	kubectl delete pvc --namespace "$K8S_NAMESPACE" -l "app.kubernetes.io/instance=$releasename"
+          fi
         else
           helm delete "$releasename" --purge \
           || print "Warning: Could not delete $releasename"
@@ -212,6 +215,9 @@ function do_execute_k8s_command_on_service {
           then
           helm uninstall "$releasename" --namespace "$K8S_NAMESPACE" \
           || print "Warning: Could not delete $releasename"
+          if [[ -n $(kubectl get pvc --namespace "$K8S_NAMESPACE" -l "app.kubernetes.io/instance=$releasename" 2>/dev/null) ]];then
+          	kubectl delete pvc --namespace "$K8S_NAMESPACE" -l "app.kubernetes.io/instance=$releasename"
+          fi
         else  
           helm delete "$releasename" --purge >/dev/null \
           || print "Warning: Could not delete $releasename"


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
When removing an installation that has persistent storage enabled with ./easy2use remove the eiffel-mongodb-eiffel is removed but not data-eiffel-rabbitmq-eiffel-0

### Description of the Change

- The "eiffel-mongodb-eiffel" service deployed using "Deployment" kind, hence all of its pv/pvc resources will be remove as part of easy2use setup cleanup using "helm uninstall"
- Since the "eiffel-rabbitmq-eiffel" service in Eiffel easy2use is deployed using "Statefulset" kind, it is creating a unique pvc for each of its pod. These pvc's cannot be remove using "helm uninstall" as these pvc's are created/controlled by Statefulset,. Hence these pvc's can be deleted as part of the easy2use setup cleanup using native "kubectl" command under k8s cli utilities bash script.

### Alternate Designs
The rabbitmq service deployment model can be changed from statefulset to Deployment kind, if needed

### Benefits
This will be a proper cleanup of easy2use sandbox by removing all of its pv/pvc resources. 

### Possible Drawbacks
N/A

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Sankar Palanivel sankar.palanivel@est.tech
