### PR TITLE
Update local k8s minikube configure script

### DIFF
--- a/utilities/K8S/configure_local_k8s_minikube.sh
+++ b/utilities/K8S/configure_local_k8s_minikube.sh
@@ -23,24 +23,8 @@
 # Add Ingress
 minikube addons enable ingress
 
-# Add Kubernetes Graphs
-kubectl create -f https://raw.githubusercontent.com/kubernetes/heapster/master/deploy/kube-config/influxdb/influxdb.yaml
-kubectl create -f https://raw.githubusercontent.com/kubernetes/heapster/master/deploy/kube-config/influxdb/heapster.yaml
-kubectl create -f https://raw.githubusercontent.com/kubernetes/heapster/master/deploy/kube-config/influxdb/grafana.yaml
-
-# Add NGINX
-helm install stable/nginx-ingress --name my-nginx --replace
-helm install stable/nginx-ingress --name my-nginx --set rbac.create=true --replace
-
-# Install Tiller
-helm init
-
 #RBAC
 kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
 # Show minikube ip
-minikube ip
-
-# Start Dashboard
-echo "Open K8S Dashboard in Browser:"
-minikube dashboard
+echo MinikubeIP: $(minikube ip)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
#73 

### Description of the Change

- "./easy2use configure-local-k8s-minikube Eiffel -t Kubernetes" command on local minikube cluster throws error, as it has duplicate ingress controller entries and legacy/deprecated kubernetes resources creation for heapster. 
- nginx-ingress controller entries can be removed, since ingress can be enabled from minikube addons itself
- Heapster k8s resource creation entries can be removed as they are unsupported/deprecated
- Remove the minikube dashboard setup from this script, as it is not needed as a prerequisite to bring up easy2use services
- Remove "helm init"

### Alternate Designs
N/A

### Benefits
A properly configured local minikube setup which can be used to deploy Eiffel easy2use services

### Possible Drawbacks
The Eiffel easy2use setup will be deployed without a monitoring resources and this will not be a showstopper for users to access the eiffel services

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Sankar Palanivel sankar.palanivel@est.tech
