### PR TITLE
Namespace not removed (#25).

### DIFF
--- a/easy2use
+++ b/easy2use
@@ -415,11 +415,12 @@ function do_remove {
     source k8s_bundle_functions.bash
     if [ -z "$services" ] && [ -z "$package" ]
     then
-      [[ -f "./packages/max.sh" ]] || \
-        bail_out "K8S package file max.sh do not exist for K8S"
-      package="max"
+      print "Services and package are not defined. Namespace '${K8S_NAMESPACE}' will be deleted permanently."
+      kubectl delete namespace ${K8S_NAMESPACE}
+    else
+      execute_k8s_command "delete" "$package" "$services"
     fi
-    execute_k8s_command "delete" "$package" "$services"
+
     cd ..
   fi
 


### PR DESCRIPTION
### Applicable Issues
Fixes #25

### Description of the Change
Namespace is deleted permanently if in the command the flags "package" and "services" are not defined. If they are defined then the namespace is not deleted.
For example,
- The execution of the command **./easy2use remove -t Kubernetes -n <_namespace_> Eiffel -y** will _delete_ the namespace.
- The execution of the command **./easy2use remove -t Kubernetes -n <_namespace_> -s <_service_> Eiffel -y** will _not delete_ the namespace.

### Alternate Designs
N/A

### Benefits
The cluster is not getting cluttered by namespaces. Command is more realistic in this case deleting everything.

### Possible Drawbacks
Perhaps a developer wouldn't like the namespace to be deleted automatically in order to reuse it again for new deployment. Yet, this one can be fixed via the command **./easy2use start ...** which can be modified in order to create the given namespace, if not exist.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Panagiotis Efstratiou panagiotis.efstratiou@ericsson.com
