### PR TITLE
Add support for latest Docker and the new docker compose plugin in docker-cli.

### DIFF
--- a/bundles/Eiffel/docker-compose.yml
+++ b/bundles/Eiffel/docker-compose.yml
@@ -29,7 +29,7 @@
 # Author: michael.frick@ericsson.com
 #
 ##################################################################################################
-version: "3.7"
+version: "3.8"
 services:
   mongodb:
     restart: always

--- a/easy2use
+++ b/easy2use
@@ -184,6 +184,15 @@ function parse_arguments {
     shift # move to next key-value pair
   done
 
+  # Check if new or old docker compose command is available in environment
+  docker compose &> /dev/null
+  if [ "$?" == "0" ];
+  then
+    DOCKER_COMPOSE_CMD="docker compose"
+  else
+    DOCKER_COMPOSE_CMD="docker-compose"
+  fi
+
   # Join all given services to a space separated string
   [[ -z ${services_string} ]] || \
     services=$(echo ${services_string} | tr ',' ' ')
@@ -408,7 +417,7 @@ function do_remove {
     then
       bail_out "Docker: The remove command can NOT be used together with service(s) and/or package"
     fi
-      call "docker-compose down --volumes" $noop
+      call "$DOCKER_COMPOSE_CMD down --volumes" $noop
   elif [ "$TARGET_TYPE" == "Kubernetes" ]
   then
     cd K8S
@@ -446,7 +455,7 @@ function do_restart {
     cd ${bundles_path}/$bundle/docker-compose
     if [ -z "$services" ] && [ -z "$package" ]
     then
-      call "docker-compose restart" $noop
+      call "$DOCKER_COMPOSE_CMD restart" $noop
     else
       execute_docker_command "restart" "" "$package" "$services"
     fi
@@ -527,7 +536,7 @@ function do_status {
 
   if [ "$TARGET_TYPE" == "Docker" ]
   then
-    call "docker-compose ps" $noop
+    call "$DOCKER_COMPOSE_CMD ps" $noop
   elif [ "$TARGET_TYPE" == "Kubernetes" ]
   then
     print "Command 'status' is not yet implemented for Kubernetes"

--- a/utilities/cli/docker_utils.bash
+++ b/utilities/cli/docker_utils.bash
@@ -34,25 +34,25 @@
 #  $2: Flag for docker-compose
 #-----------------------------
 function execute_docker_command {
-  local docker_compose_cmd="$1"
+  local docker_compose_sub_cmd="$1"
   local docker_compose_flag="$2"
   local package="$3"
   local services="$4"
 
-  verbose "execute_docker_command cmd: ${docker_compose_cmd}"
+  verbose "execute_docker_command cmd: ${docker_compose_sub_cmd}"
   verbose "execute_docker_command flag: ${docker_compose_flag}"
 
   if [ -z "$services" ] && [ -z "$package" ]
   then
-    print "Docker ${docker_compose_cmd}"
+    print "Docker ${docker_compose_sub_cmd}"
     call "$DOCKER_COMPOSE_CMD stop" $noop
 
   else
     if [ ! -z "$services" ]
     then
       services_string=$(echo $services | tr ',' ' ')
-      print "Docker ${docker_compose_cmd} service(s): ${services_string}"
-      call "$DOCKER_COMPOSE_CMD ${docker_compose_cmd} ${docker_compose_flag} ${services_string}" $noop
+      print "Docker ${docker_compose_sub_cmd} service(s): ${services_string}"
+      call "$DOCKER_COMPOSE_CMD ${docker_compose_sub_cmd} ${docker_compose_flag} ${services_string}" $noop
     fi
 
     if [ ! -z "$package" ]
@@ -61,8 +61,8 @@ function execute_docker_command {
         bail_out "Package file: $package.sh specified do not exist"
 
       source ./packages/$package.sh
-      print "Docker ${docker_compose_cmd} package service(s): ${docker_package_services}"
-      call "$DOCKER_COMPOSE_CMD ${docker_compose_cmd} ${docker_compose_flag} ${docker_package_services}" $noop
+      print "Docker ${docker_compose_sub_cmd} package service(s): ${docker_package_services}"
+      call "$DOCKER_COMPOSE_CMD ${docker_compose_sub_cmd} ${docker_compose_flag} ${docker_package_services}" $noop
     fi
   fi
 }

--- a/utilities/cli/docker_utils.bash
+++ b/utilities/cli/docker_utils.bash
@@ -45,14 +45,14 @@ function execute_docker_command {
   if [ -z "$services" ] && [ -z "$package" ]
   then
     print "Docker ${docker_compose_cmd}"
-    call "docker-compose stop" $noop
+    call "$DOCKER_COMPOSE_CMD stop" $noop
 
   else
     if [ ! -z "$services" ]
     then
       services_string=$(echo $services | tr ',' ' ')
       print "Docker ${docker_compose_cmd} service(s): ${services_string}"
-      call "docker-compose ${docker_compose_cmd} ${docker_compose_flag} ${services_string}" $noop
+      call "$DOCKER_COMPOSE_CMD ${docker_compose_cmd} ${docker_compose_flag} ${services_string}" $noop
     fi
 
     if [ ! -z "$package" ]
@@ -62,7 +62,7 @@ function execute_docker_command {
 
       source ./packages/$package.sh
       print "Docker ${docker_compose_cmd} package service(s): ${docker_package_services}"
-      call "docker-compose ${docker_compose_cmd} ${docker_compose_flag} ${docker_package_services}" $noop
+      call "$DOCKER_COMPOSE_CMD ${docker_compose_cmd} ${docker_compose_flag} ${docker_package_services}" $noop
     fi
   fi
 }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
Not possible to start Eiffel bundle and containers with newer Docker-compose tool that comes as plugin in newer Docker-Cli tool.

### Description of the Change
Adding support in Easy2Use CLI for newer docker-compose that comes as a plugin to the normal Docklin-cli tool.
Stepped Docker-compose yaml specification version to latest version which currently are version 3.8.

Link to how Docker compose plugin are installed and executed as a sub-command to docker command:
https://docs.docker.com/compose/install/linux/

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Support new docker compose tool that comes as plugin to normal Docklin-cli tool.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
